### PR TITLE
Feature/mongodb 3.6 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM ubuntu:18.04
 
 ARG UNIFI_VERSION
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 This is what it sounds like - the Unifi Controller in a Docker container.
 
+## Heads Up - Mongodb 3.6
+
+In the event I am not the only one using this image, you will need to work around some annoyances I am creating. I am now building these images off of Ubuntu 18.04, which has mongodb 3.6.x (versus the 3.2.x in Debian Stretch). The reason is simple - 3.2 isn't supported by the main project anymore, and Ubiquity supports 3.6 now.
+
+Starting with builds after 6.2.25, you're likely going to have issues doing an in-place upgrade (it exploded for me when I tested it, for example). I have ideas as to why, and maybe how to fix them properly, but here's the easiest workaround: do a manual backup first.
+
+A special tagged image exists for doing the upgrade (6.2.25-mongodb36). Docker will only keep this image around a few months, so you should plan around migrating soon. If you're not ready just yet, switch to 6.2.25-mongodb32. To migrate, do the following:
+
+1. Perform a manual backup from the Unifi console
+1. If you replaced the Unifi certificate, back up your custom keystore file
+1. Delete your existing container and volumes
+1. Run the new container (ex. using the 6.2.25-mongodb36 tag)
+1. Upload your backup file to the installer
+1. Wait for the restore to finish, then log in and check on your sites
+1. Restore your custom keystore, if you had one
+1. Do a regular backup of your controller
+
 ## Tags
 
 I build images for three architectures:


### PR DESCRIPTION
Switch to Ubuntu 18.04 as a base, upgrading to mongodb 3.6.